### PR TITLE
RFC: Bundler Version Locking

### DIFF
--- a/text/0000-bundler-version-locking.md
+++ b/text/0000-bundler-version-locking.md
@@ -17,9 +17,45 @@ This should happen transparently during the normal `bundle install`/`bundle exec
 
 # Motivation
 
-There are many times where locking your Bundler version is useful.
-The existence of `BundlerVersionFinder` shows that, but the initial attempt
-caused innumerable problems. This is an attempt to resolve those problems.
+## Usability
+
+Bundler is used in a wide variety of scenarios. Experience has proven that
+seemingly-minor changes in Bundler can cause things to break in certain
+situations, even if the intention was to preserve compatibility.
+
+By explicitly listing Bundler as a dependency, like it allows you to do with
+other dependencies, you can ensure people are using the expected versions.
+
+To keep the exact version, either use a tight constraint (e.g. `= 2.2.24`)
+or use a lockfile. To use a version expected to be compatible, you can
+use a `~>` constraint (e.g. `~> 2.2.0`).
+
+## Source Analysis
+
+Bundler is currently the only Ruby dependency where you can not reliably
+determine from the source code for a project which version will be run.
+Every other gem a project depends on is included in the `Gemfile.lock`,
+and the Ruby version is in the `Gemfile` and/or `.ruby-version`.
+
+Even bundler-audit [does not currently check the Bundler version](https://github.com/rubysec/bundler-audit/pull/299)
+due to the complexity of doing so.
+
+Any sufficiently complex software has security vulnerabilities, and Bundler
+is no exception. By including the version of Bundler used in Gemfile.lock,
+and respecting the version in the Gemfile when Gemfile.lock does not exist,
+we bring Bundler in line with the rest of the dependencies.
+
+## Forcing Bundler Updates
+
+If Bundler has a bug that causes problems for you, or a vulnerability that
+affects you, the best you could currently do is have a script install the
+appropriate version. However, this can only work if people remember to run
+the script.
+
+By allowing the Gemfile and Gemfile.lock files to dictate the version of
+Bundler that is used, it becomes possible to force Bundler updates to avoid
+bugs and vulnerabilities. Running `bundle install` becomes enough to update
+_every_ dependency, including Bundler itself.
 
 # Guide-level explanation
 

--- a/text/0000-bundler-version-locking.md
+++ b/text/0000-bundler-version-locking.md
@@ -35,6 +35,8 @@ Installing Bundler 2.0.2...
 Switching to Bundler 2.0.2...
 (... rest of output, as normal ...)
 $ bundle install
+Bundler 2.1.4 is being run, but "Gemfile" requires version 2.0.2.
+Switching to Bundler 2.0.2...
 (... normal output ...)
 ```
 
@@ -140,3 +142,8 @@ The approach in this RFC tries to ensure:
 # Unresolved questions
 
 There are many quality-of-life things that could be added, like telling users if they're relying on an outdated Bundler version, but I feel this can be added after the fact.
+
+Things I want to figure out:
+
+1. If the version it needs is found, should it still print a message explaining what version was ran and which was switched to? Or should it avoid printing anything unless there's a problem?
+   - In theory, passing `--verbose` includes this, because the first line from `bundle install --verbose` is `Running `bundle install --verbose` with bundler 2.0.2`

--- a/text/0000-bundler-version-locking.md
+++ b/text/0000-bundler-version-locking.md
@@ -29,13 +29,13 @@ Output:
 
 ```
 $ bundle install
-Bundler 2.1.4 is being run, but "Gemfile" requires version 2.0.2.
+Bundler 2.1.4 is being run, but "Gemfile" requires version "= 2.0.2".
 Installing Bundler 2.0.2...
 (... output of installing Bundler 2.0.2 ...)
 Switching to Bundler 2.0.2...
 (... rest of output, as normal ...)
 $ bundle install
-Bundler 2.1.4 is being run, but "Gemfile" requires version 2.0.2.
+Bundler 2.1.4 is being run, but "Gemfile" requires version "= 2.0.2".
 Switching to Bundler 2.0.2...
 (... normal output ...)
 ```
@@ -56,7 +56,7 @@ Output:
 
 ```
 $ bundle install
-Bundler 2.1.4 is being run, but "Gemfile" requires version 2.0.2.
+Bundler 2.1.4 is being run, but "Gemfile" requires version "~> 2.0".
 Switching to Bundler 2.0.2...
 (... normal output ...)
 ```
@@ -85,7 +85,7 @@ Output:
 
 ```
 $ bundle install
-Bundler 2.1.4 is being run, but "blah.gemspec" requires version 2.0.2.
+Bundler 2.1.4 is being run, but "blah.gemspec" requires version "~> 2.0".
 Switching to Bundler 2.0.2...
 (... normal output ...)
 ```

--- a/text/0000-bundler-version-locking.md
+++ b/text/0000-bundler-version-locking.md
@@ -1,0 +1,142 @@
+- Feature Name: bundler_version_locking
+- Start Date: 2020-09-01
+- RFC PR: (leave this empty)
+- Bundler Issue: (leave this empty)
+
+# Summary
+
+If a user specifies a required Bundler version in the Gemfile/gemspec, it should be installed and used during the normal `bundle install`/`bundle exec` workflow.
+
+# Motivation
+
+There are many times where locking your Bundler version is useful. The existence of `BundlerVersionFinder` shows that, but that approach clearly has not worked. **This RFC assumes that `BundlerVersionFinder` is removed first. The discussion on whether or not to do that should be had elsewhere.**
+
+# Guide-level explanation
+
+## Example 1
+
+For this example, assume Bundler 2.1.4 is installed but Bundler 2.0.2 is not.
+
+Gemfile:
+
+```
+source "https://rubygems.org"
+
+gem "bundler", "= 2.0.2"
+```
+
+Output:
+
+```
+$ bundle install
+Bundler 2.1.4 is being run, but "Gemfile" requires version 2.0.2.
+Installing Bundler 2.0.2...
+(... output of installing Bundler 2.0.2 ...)
+Switching to Bundler 2.0.2...
+(... rest of output, as normal ...)
+$ bundle install
+(... normal output ...)
+```
+
+## Example 2
+
+For this example, assume both Bundler 2.0.2 and Bundler 2.1.4 are installed.
+
+Gemfile:
+
+```
+source "https://rubygems.org"
+
+gem "bundler", "~> 2.0"
+```
+
+Output:
+
+```
+$ bundle install
+Bundler 2.1.4 is being run, but "Gemfile" requires version 2.0.2.
+Switching to Bundler 2.0.2...
+(... normal output ...)
+```
+
+## Example 3
+
+For this example, assume both Bundler 2.0.2 and Bundler 2.1.4 are installed.
+
+Gemfile:
+
+```
+source "https://rubygems.org"
+
+gemspec
+```
+
+blah.gemspec:
+
+```
+<...>
+   spec.add_development_dependency "bundler", "~> 2.0"
+<...>
+```
+
+Output:
+
+```
+$ bundle install
+Bundler 2.1.4 is being run, but "blah.gemspec" requires version 2.0.2.
+Switching to Bundler 2.0.2...
+(... normal output ...)
+```
+
+## Example 4
+
+For this example, assume both Bundler 2.0.2 and Bundler 2.1.4 are installed.
+Note that since the default behavior is to run the newest version installed, and that matches the requirement, it never needs to switch versions.
+
+Gemfile:
+
+```
+source "https://rubygems.org"
+
+gem "bundler", "~> 2.1"
+```
+
+Output:
+
+```
+$ bundle install
+(... normal output ...)
+```
+
+# Reference-level explanation
+
+First, the `BundlerVersionFinder` would be removed, as mentioned in "Motivation."
+
+Then, Bundler would do the following when `bundle` is executed:
+
+1. If the first argument isn't `_<bundler version>_` _and_ the Gemfile/gemspec specify a required version of Bundler _and_ the requirement isn't met by the currently-running version:
+   a. Install the required version of Bundler, if needed.
+   b. Replace the current process with `bundle _<required version>_ <args...>` (e.g. something along the lines of `Kernel.exec("bundle", "_#{required_version}_", *args)`)
+2. Run as normal.
+
+# Drawbacks
+
+TBD. (I'm sure there are some.)
+
+# Rationale and Alternatives
+
+The main alternative is a refinement of the BundlerVersionFinder, but I think the approach in this RFC better follows the [principle of least surprise](https://en.wikipedia.org/wiki/Principle_of_least_astonishment) by relying on existing knowledge and assumptions.
+
+The approach in this RFC tries to ensure:
+
+1. It is inherently opt-in: it won't do anything if you don't explicitly list Bundler as a dependency.
+2. The user has more control:
+    - It's opt-in, so it won't get in the way if it's not actively wanted.
+    - By implementing it in terms of the `_<some version>_` feature, we provide a way for users to override the behavior if needed.
+3. It builds on existing conventions:
+    - Locking the Bundler version is done in the same place and way as any other dependency.
+    - Changing the locked Bundler version is done the same way as any other dependency.
+
+# Unresolved questions
+
+There are many quality-of-life things that could be added, like telling users if they're relying on an outdated Bundler version, but I feel this can be added after the fact.

--- a/text/0000-bundler-version-locking.md
+++ b/text/0000-bundler-version-locking.md
@@ -13,7 +13,7 @@ There are many times where locking your Bundler version is useful. The existence
 
 # Guide-level explanation
 
-If you need to pin the Bundler version, simply specify it in your `Gemfile` or `gemspec and run `bundle install` as usual.
+If you need to pin the Bundler version, simply specify it in your `Gemfile` or `gemspec` file and run `bundle install` as usual.
 
 If the running version doesn't meet the requirements, Bundler will install the specified version of itself, and then re-run itself using that version.
 
@@ -129,13 +129,13 @@ $ bundle install
 Then, Bundler would do the following when `bundle` is executed:
 
 1. If the first argument isn't `_<bundler version>_` _and_ the Gemfile/gemspec specify a required version of Bundler _and_ the requirement isn't met by the currently-running version:
-   a. Install the required version of Bundler, if needed.
-   b. Replace the current process with `bundle _<required version>_ <args...>` (e.g. something along the lines of `Kernel.exec($0, "_#{required_version}_", *ARGV)`)
+   a. Install the required version of Bundler if needed, respecting Gemfile.lock as normal.
+   b. Replace the current process with the equivalent of `bundle <args...>`, using the correct version.
 2. Run as normal.
 
 # Drawbacks
 
-TBD. (I'm sure there are some.)
+This does add localized complexity to part of the codebase, either in the binstub or the `bundle install` process (depending on the implementation).
 
 # Rationale and Alternatives
 
@@ -144,7 +144,7 @@ The approach in this RFC tries to ensure:
 1. It is inherently opt-in: it won't do anything if you don't explicitly list Bundler as a dependency.
 2. The user has more control:
     - It's opt-in, so it won't get in the way if it's not actively wanted.
-    - By implementing it in terms of the `_<some version>_` feature, we provide a way for users to override the behavior if needed.
+    - By respecting the `_<some version>_` feature, we provide a way for users to override the behavior if needed.
 3. It builds on existing conventions:
     - Locking the Bundler version is done in the same place and way as any other dependency.
     - Changing the locked Bundler version is done the same way as any other dependency.
@@ -153,4 +153,6 @@ I am not aware of any alternatives that accomplish all of these.
 
 # Unresolved questions
 
-There are many quality-of-life things that could be added, like telling users if they're relying on an outdated Bundler version, but I feel this can be added after the fact.
+There are many quality-of-life things that could be added, like telling users if they're relying on an outdated Bundler version, but these can be added after the fact.
+
+The exact implentation is still unclear &mdash; it could be part of `bundle install`, or installing the right Bundler version could be handled by the `bundle` binstub.


### PR DESCRIPTION
~~**NOTE**: This RFC is proposed as an alternative to the "Bundler version switcher", and assumes that is being removed first. Whether or not to remove it should be discussed elsewhere.~~

This RFC no longer assumes BundlerVersionFinder is removed, and there is a proof-of-concept (see https://github.com/rubygems/rfcs/pull/29#issuecomment-731333194) implemented without removing it, but they may be redundant in some cases.

[Rendered](https://github.com/duckinator/rfcs/blob/bundler-version-locking/text/0000-bundler-version-locking.md)